### PR TITLE
Force time series to be ints, not ISO time stamps.

### DIFF
--- a/snews/models/messages.py
+++ b/snews/models/messages.py
@@ -297,7 +297,7 @@ class TimingTierMessage(TierMessageBase):
         description="Time of the first neutrino in the event in ISO 8601-1:2019 format"
     )
 
-    timing_series: List[Union[str, int]] = Field(
+    timing_series: List[int] = Field(
         ...,
         title="Timing Series",
         description="Timing series of the event",
@@ -331,12 +331,11 @@ class TimingTierMessage(TierMessageBase):
         return self
 
     @field_validator("timing_series")
-    def _validate_timing_series(cls, v: List[str]):
-        try:
-            converted_timestamps = list(map(convert_timestamp_to_ns_precision, v))
-        except ValueError:
-            raise ValueError("Timing series entries must be in ISO 8601-1:2019 format")
-        return converted_timestamps
+    def _validate_timing_series(cls, v: List[int]):
+        if not all(isinstance(_t, int) for _t in v):
+            raise ValueError('Timing series must be integers')
+
+        return v
 
     @model_validator(mode="after")
     def _validate_model(self):


### PR DESCRIPTION
This is a potential fix to `TimingTierMessage` to store the timing series as a list of integers (positive or negative, potentially unsorted) rather than strings in ISO format, which are being interpreted as UNIX timestamps.